### PR TITLE
Some improvements of the markdown -> html export

### DIFF
--- a/lib/markdown.ml
+++ b/lib/markdown.ml
@@ -416,7 +416,9 @@ and para p =
   | Heading (1,pt) as h -> <:html<<h1>$heading_content h pt$</h1>&>>
   | Heading (2,pt) as h -> <:html<<h2>$heading_content h pt$</h2>&>>
   | Heading (3,pt) as h -> <:html<<h3>$heading_content h pt$</h3>&>>
-  | Heading (_,pt) as h -> <:html<<h4>$heading_content h pt$</h4>&>>
+  | Heading (4,pt) as h -> <:html<<h4>$heading_content h pt$</h4>&>>
+  | Heading (5,pt) as h -> <:html<<h5>$heading_content h pt$</h5>&>>
+  | Heading (_,pt) as h -> <:html<<h6>$heading_content h pt$</h6>&>>
   | Quote pl         -> <:html<<blockquote>$paras pl$</blockquote>&>>
   | Ulist (pl,pll)   -> let l = pl :: pll in <:html<<ul>$li l$</ul>&>>
   | Olist (pl,pll)   -> let l = pl :: pll in <:html<<ol>$li l$</ol>&>>


### PR DESCRIPTION
Hello,
I currently use ocaml-cow's markdown export for a small project, and I tried to bring some improvements to the exported html.
- Headings, lists, quote and code blocs (`<pre><code>`...) shouldn't be put in `<p>...</p>` blocks. The html w3c validator complains about that. A commit corrects this point.
- By adding two more lines following the same pattern than the existing ones, we can add support for h5 and h6 titles - that are supposed to be supported in markdown (inserted with `#####` and `######`)
- I add an option in the functions Xml.to_string (and thus Html.to_string) to specify an indentation level. The code was already written in the Xml lib, but the indentation level was hardcoded as None in the to_string function. This can help to have a pretty xml output (unfortunately, it kinda breaks html output that uses `<pre>` sections, by adding extra '\n' between all content lines)
- It seems to me (and to the people I ask) that putting the attributes of a heading anchor into the heading tag itself is much better than putting them in an empty link, itself inside the heading (moreover, the current solution causes some css problems). Example of the modification brought by the commit, for a markdown `# Title`:
  before: `<h1><a name="h1-Title" class="anchor-toc"> </a> Title </h1>`
  now: `<h1 name="h1-Title" class="anchor-toc"> Title </h1>`

Cheers !
