### PR TITLE
Fix parsing of XML/HTML tags with empty attributes.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.9.1 (trunk):
+* Fix parsing of empty attributes in XML/HTML/XHTML.
+
 0.9.0 (20-Dec-2013):
 * Remove all the Markdown variants except `Omd`, which now claims the `Cow.Markdown` module name.
 * Clarify the repository license as ISC.

--- a/_vars
+++ b/_vars
@@ -1,5 +1,5 @@
 NAME=cow
-VERSION=0.9.0
+VERSION=0.9.1
 LIB=cow
 SYNTAX="pa_cow"
 DEPS="dyntype.syntax dyntype re ulex uri xmlm omd"

--- a/syntax/xml/qast.ml
+++ b/syntax/xml/qast.ml
@@ -44,6 +44,7 @@ let rec list_of_t x acc =
 let get_string _loc m =
   match m with
   | <:expr< [ `Data $str:x$ ] >> -> <:expr< $str:x$ >>
+  | <:expr< [] >> -> <:expr< $str:""$ >>
   | _ ->
     <:expr< match $m$ with [ [`Data str] -> str | _ -> raise Parsing.Parse_error ] >>
 

--- a/tests/render.ml
+++ b/tests/render.ml
@@ -7,6 +7,8 @@ let xml_decl = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
 let a = <:xml<<a>a</a>&>>
 let b = <:xml<<b/>&>>
 let c = <:xml<<c>$a$ $b$ $a$</c>&>>
+let d = <:xml<<a foo=""></a>&>>
+let _d = Xml.to_string d
 let opt = Some a
 let opt' = None
 let int = 3


### PR DESCRIPTION
This previously lead to a dynamic `Parsing.Parse_error`, so this
partially fixes #30 too.

@samoht does this look right to you?
