### PR TITLE
Make all syntax archive dependencies explicit and ordered

### DIFF
--- a/META.in
+++ b/META.in
@@ -7,7 +7,7 @@ requires = "dyntype dyntype.syntax ezjsonm re re.str ulex uri xmlm omd"
 package "syntax" (
  description = "Syntax extension for COW"
  requires = "camlp4 str dyntype.syntax xmlm ezjsonm"
- archive(syntax, preprocessor) = "xmlm.cma str.cma pa_cow.cma ezjsonm.cma"
+ archive(syntax, preprocessor) = "xmlm.cma str.cma uutf.cma jsonm.cma ezjsonm.cma pa_cow.cma"
  archive(syntax, toploop) = "pa_cow.cma"
  exists_if = "pa_cow.cma"
 )


### PR DESCRIPTION
ocamlfind query doesn't do combined directory and archive listing recursive search correctly
ocamlfind query can list directories recursively correctly
ocamlfind query can list archives correctly
therefore, we need to list all used archives in order to get ocamlfind query to tell us information useful for a preprocessor command line
