### PR TITLE
Deprecate the Atom module

### DIFF
--- a/lib/atom.mli
+++ b/lib/atom.mli
@@ -15,7 +15,9 @@
  *
  *)
 
-(** The Atom Syndication format. See RFC4287 for the full specification *)
+(** The Atom Syndication format. See RFC4287 for the full specification.
+
+    @deprecated Please use the [Syndic] package instead. *)
 
 type author = {
   name  : string;


### PR DESCRIPTION
Syndic.Atom has much more complete parsing and printing for the Atom
format.  New projects should use it.