### PR TITLE
Add additional functionality to the CSS library

### DIFF
--- a/lib/css.ml
+++ b/lib/css.ml
@@ -132,6 +132,7 @@ let polygradient = function
                   background: $low$; /* for non-css3 browsers */
                   background: -webkit-radial-gradient($behaviour$, $low$, $high$);
                   background: -mos-radial-gradient($behaviour$, $low$, $high$);
+                  background: -o-radial-gradient($behaviour$, $low$, $high$);
                   background: radial-gradient($behaviour$, $low$, $high$);
                 >>
             in impl
@@ -151,6 +152,7 @@ let polygradient = function
                   background: $low$;
                   background: -webkit-linear-gradient($behaviour''$, $low$, $high$);
                   background: -moz-linear-gradient($behaviour''$, $low$, $high$);
+                  background: -o-linear-gradient($behaviour''$, $low$, $high$);
                   background: linear-gradient($behaviour''$, $low$, $high$);
                 >>
             in impl
@@ -216,9 +218,9 @@ let reset_padding =
     h1, h2, h3, h4, h5, h6,
     ul, ol, dl, li, dt, dd, p,
     blockquote, pre, form, fieldset,
-    table, th, td { 
-      margin: 0; 
-      padding: 0; 
+    table, th, td {
+      margin: 0;
+      padding: 0;
    }
   >>
 

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -123,28 +123,61 @@ module Css = struct
       | Exprs er -> assert false
 end
 
+type gradient_type = [ `Linear | `Radial ]
+
+let polygradient = function
+    | `Radial ->
+            let impl ?(behaviour = <:css<circle>>) ?(low = <:css<#0a0a0a>>) ?(high = <:css<#ffffff>>) =
+                <:css<
+                  background: $low$; /* for non-css3 browsers */
+                  background: -webkit-radial-gradient($behaviour$, $low$, $high$);
+                  background: -mos-radial-gradient($behaviour$, $low$, $high$);
+                  background: radial-gradient($behaviour$, $low$, $high$);
+                >>
+            in impl
+    | `Linear ->
+            let impl ?(behaviour = <:css<to right>>) ?(low = <:css<#0a0a0a>>) ?(high = <:css<#ffffff>>) =
+                let behaviour' = String.lowercase @@ String.trim @@ Css.to_string behaviour in
+                let behaviour'' =
+                    begin match behaviour' with
+                    | "right" -> <:css<to left>>
+                    | "left" -> <:css<to right>>
+                    | "top" -> <:css<to bottom>>
+                    | "bottom" -> <:css<to top>>
+                    | "to right" | "to left" | "to top" | "to bottom" -> behaviour
+                    end
+                in
+                <:css<
+                  background: $low$;
+                  background: -webkit-linear-gradient($behaviour''$, $low$, $high$);
+                  background: -moz-linear-gradient($behaviour''$, $low$, $high$);
+                  background: linear-gradient($behaviour''$, $low$, $high$);
+                >>
+            in impl
+
 (* From http://www.webdesignerwall.com/tutorials/cross-browser-css-gradient/ *)
-let gradient ~low ~high =
+let gradient ?(low = <:css<#0a0a0a>>) ?(high = <:css<#ffffff>>) =
   <:css<
     background: $low$; /* for non-css3 browsers */
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=$high$, endColorstr=$low$); /* for IE */
-    background: -webkit-gradient(linear, left top, left bottom, from($high$), to($low$)); /* for webkit browsers */
-    background: -moz-linear-gradient(top,  $high$,  $low$); /* for firefox 3.6+ */
+    background: -webkit-gradient(linear, left top, left bottom, from($high$), to($low$)); /* for older webkit browsers */
+    background: -moz-linear-gradient(top,  $high$,  $low$); /* for firefox 3.6 to 15 */
+    background: -o-linear-gradient(top, $high$, $low$); /* for older versions of Opera (and the sake of completeness) */
  >>
 
-let text_shadow =
+let text_shadow ?(h = <:css<0>>) ?(v = <:css<1px>>) ?(blur = <:css<1px>>) ?(color = <:css<rgba(0,0,0,.3)>>) =
   <:css<
-    text-shadow: 0 1px 1px rgba(0,0,0,.3);  
+    text-shadow: $h$ $v$ $blur$ $color$;
   >>
 
-let box_shadow =
+let box_shadow ?(h = <:css<0>>) ?(v = <:css<1px>>) ?(blur = <:css<1px>>) ?(color = <:css<rgba(0,0,0,.3)>>) =
   <:css<
-    -webkit-box-shadow: 0 1px 2px rgba(0,0,0,.2);
-    -moz-box-shadow: 0 1px 2px rgba(0,0,0,.2);
-    box-shadow: 0 1px 2px rgba(0,0,0,.2);
+    -webkit-box-shadow: $h$ $v$ $blur$ $color$;
+    -moz-box-shadow: $h$ $v$ $blur$ $color$;
+    box-shadow: $h$ $v$ $blur$ $color$;
   >>
 
-let rounded =
+let rounded ?(radius = <:css<.5em>>) =
   <:css<
     -webkit-border-radius: .5em;
     -moz-border-radius: .5em;

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -62,40 +62,36 @@ val unroll : t -> t
     [polygradient `Radial <:css<circle>> <:css<#ff0000>> <:css<#00ff00>>]
     will produce a red and green centered circular radial
     gradient. *)
-val polygradient : gradient_type -> ?behaviour:t -> ?low:t -> ?high:t -> t
+val polygradient
+  : gradient_type ->
+    ?behaviour:t ->
+    ?low:t ->
+    ?high:t ->
+    unit -> t
 
 (** Emit a CSS gradient style that linearly interpolates
     between the [low] and [high] colors moving from top to
     bottom; the default values of [low] and [high] are
     [#0a0a0a] and [#ffffff] respectively *)
-val gradient : ?low:t -> ?high:t -> t
+val gradient
+  : ?low:t ->
+    ?high:t ->
+    unit -> t
 
 (** Emit a border style that rounds off the top border by
     [0.5em] pixels. *)
-val top_rounded : t
-
-(** Emit a border style that rounds off the top border by
-    [0.5em] pixels. *)
-val top_rounded : t
+val top_rounded : ?radius:t -> unit -> t
 
 (** Emit a border style that rounds off the bottom border
     by [0.5em] pixels. *)
-val bottom_rounded : t
+val bottom_rounded : ?radius:t -> unit -> t
 
 (** Emit a border style that rounds off all the borders by
     [radius], which has a default value of [0.5em] *)
-val rounded : ?radius:t -> t
+val rounded : ?radius:t -> unit -> t
 
-val box_shadow : ?h:t -> ?v:t -> ?blur:t -> ?color:t -> t
-val text_shadow : ?h:t -> ?v:t -> ?blur:t -> ?color:t -> t
-
-val no_padding : t
-val reset_padding : t
-val bottom_rounded : t
-val rounded : ?radius:t -> t
-
-val box_shadow : ?h:t -> ?v:t -> ?blur:t -> ?color:t -> t
-val text_shadow : ?h:t -> ?v:t -> ?blur:t -> ?color:t -> t
+val box_shadow : ?h:t -> ?v:t -> ?blur:t -> ?color:t -> unit -> t
+val text_shadow : ?h:t -> ?v:t -> ?blur:t -> ?color:t -> unit -> t
 
 val no_padding : t
 val reset_padding : t

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -40,6 +40,10 @@ type t =
 (** Print CSS to a [string] suitable for rendering *)
 val to_string : t -> string
 
+(** emits CSS containing the contents of the argument, suitable for
+    embedding in CSS format strings *)
+val of_string : string -> t
+
 (** {2 Getters} *)
 
 val expr : t -> expr

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -28,6 +28,8 @@ type prop_decl =
   | Prop of string * expr list
   | Decl of expr list * prop_decl list
 
+type gradient_type = [ `Linear | `Radial ]
+
 (** The type of CSS fragment *)
 type t =
   | Props of prop_decl list
@@ -51,9 +53,18 @@ val unroll : t -> t
 
 (** {2 CSS library} *)
 
+(** Emit a CSS gradient style that can be either a linear
+    gradient or a radial gradient (at the moment it will
+    by default produce a centered circular gradient if
+    asked for a radial gradient). For example, a call of
+    [polygradient `Radial <:css<circle>> <:css<#ff0000>> <:css<#00ff00>>]
+    will produce a red and green centered circular radial
+    gradient. *)
+val polygradient : gradient_type -> ?behaviour:t -> ?low:t -> ?high:t -> t
+
 (** Emit a CSS gradient style that linearly interpolates
     between the [low] and [high] colors *)
-val gradient : low:t -> high:t -> t
+val gradient : ?low:t -> ?high:t -> t
 
 (** Emit a border style that rounds off the top border by
     [0.5em] pixels. *)
@@ -66,18 +77,18 @@ val top_rounded : t
 (** Emit a border style that rounds off all the borders by
     [0.5em] pixels. *)
 val bottom_rounded : t
-val rounded : t
+val rounded : ?radius:t -> t
 
-val box_shadow : t
-val text_shadow : t
+val box_shadow : ?h:t -> ?v:t -> ?blur:t -> ?color:t -> t
+val text_shadow : ?h:t -> ?v:t -> ?blur:t -> ?color:t -> t
 
 val no_padding : t
 val reset_padding : t
 val bottom_rounded : t
-val rounded : t
+val rounded : ?radius:t -> t
 
-val box_shadow : t
-val text_shadow : t
+val box_shadow : ?h:t -> ?v:t -> ?blur:t -> ?color:t -> t
+val text_shadow : ?h:t -> ?v:t -> ?blur:t -> ?color:t -> t
 
 val no_padding : t
 val reset_padding : t

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -28,6 +28,8 @@ type prop_decl =
   | Prop of string * expr list
   | Decl of expr list * prop_decl list
 
+(** Utility type used to specify the type of gradient to be
+    emitted by [polygradient] *)
 type gradient_type = [ `Linear | `Radial ]
 
 (** The type of CSS fragment *)
@@ -63,20 +65,25 @@ val unroll : t -> t
 val polygradient : gradient_type -> ?behaviour:t -> ?low:t -> ?high:t -> t
 
 (** Emit a CSS gradient style that linearly interpolates
-    between the [low] and [high] colors *)
+    between the [low] and [high] colors moving from top to
+    bottom; the default values of [low] and [high] are
+    [#0a0a0a] and [#ffffff] respectively *)
 val gradient : ?low:t -> ?high:t -> t
 
 (** Emit a border style that rounds off the top border by
     [0.5em] pixels. *)
 val top_rounded : t
 
-(** Emit a border style that rounds off the bottom border by
+(** Emit a border style that rounds off the top border by
     [0.5em] pixels. *)
 val top_rounded : t
 
-(** Emit a border style that rounds off all the borders by
-    [0.5em] pixels. *)
+(** Emit a border style that rounds off the bottom border
+    by [0.5em] pixels. *)
 val bottom_rounded : t
+
+(** Emit a border style that rounds off all the borders by
+    [radius], which has a default value of [0.5em] *)
 val rounded : ?radius:t -> t
 
 val box_shadow : ?h:t -> ?v:t -> ?blur:t -> ?color:t -> t

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -57,6 +57,10 @@ val string : t -> string
     an equivalent fragment with only root declarations *)
 val unroll : t -> t
 
+val set_prop : t -> string -> string list -> t
+
+val get_prop : t -> string -> string list
+
 (** {2 CSS library} *)
 
 (** Emit a CSS gradient style that can be either a linear

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -37,7 +37,7 @@ type t =
   | Props of prop_decl list
   | Exprs of expr list
 
-(** Print CSS to a [string] suitable for rendering *)
+(** Print CSS to a string suitable for rendering *)
 val to_string : t -> string
 
 (** emits CSS containing the contents of the argument, suitable for
@@ -75,26 +75,49 @@ val polygradient
 
 (** Emit a CSS gradient style that linearly interpolates
     between the [low] and [high] colors moving from top to
-    bottom; the default values of [low] and [high] are
-    [#0a0a0a] and [#ffffff] respectively *)
+    bottom
+    @param low the color to place at the bottom of the gradient.
+               default is #0a0a0a
+    @param high the color to place at the top of the gradient.
+                default is #ffffff *)
 val gradient
   : ?low:t ->
     ?high:t ->
     unit -> t
 
-(** Emit a border style that rounds off the top border by
-    [0.5em] pixels. *)
+(** Emit a border style that rounds off the top border.
+    @param radius the radius at which to round the top corners;
+    default is 0.5em *)
 val top_rounded : ?radius:t -> unit -> t
 
-(** Emit a border style that rounds off the bottom border
-    by [0.5em] pixels. *)
+(** Emit a border style that rounds off the bottom border.
+    @param radius the radius at which to round the bottom
+                  corners; default is 0.5em *)
 val bottom_rounded : ?radius:t -> unit -> t
 
 (** Emit a border style that rounds off all the borders by
     [radius], which has a default value of [0.5em] *)
 val rounded : ?radius:t -> unit -> t
 
+(** emit a style which creates a shadow or glow around the element.
+    @param h the horizontal (from left) displacement of the shadow;
+      defaults to 0
+    @param v the vertical (from top) displacement of the shadow;
+      defaults to 1px
+    @param blur the blur/scatter effect of the shadow; defaults to
+      1px
+    @param color the color of the shadow; defaults to rgba(0,0,0,.3) *)
 val box_shadow : ?h:t -> ?v:t -> ?blur:t -> ?color:t -> unit -> t
+
+(** emit a style which creates a shadow or glow around text of an
+     element.
+    @param h the horizontal (from left) displacement of the shadow;
+      defaults to 0
+    @param v the vertical (from top) displacement of the shadow;
+      defaults to 1px
+    @param blur the blur/scatter effect of the shadow; defaults to
+      1px
+    @param color the color of the shadow; defaults to rgba(0,0,0,.3) *)
 val text_shadow : ?h:t -> ?v:t -> ?blur:t -> ?color:t -> unit -> t
 
 val no_padding : t

--- a/lib/html.ml
+++ b/lib/html.ml
@@ -81,13 +81,13 @@ let to_string t =
 let of_string ?enc str =
   Xml.of_string ~entity:Xhtml.entity ?enc str
 
-(* @deprecated *)
+(** @deprecated *)
 type link = {
   text : string;
   href: string;
 }
 
-(* @deprecated *)
+(** @deprecated *)
 let html_of_link l : t =
   <:xml<<a href=$str:l.href$>$str:l.text$</a>&>>
 

--- a/lib/html.ml
+++ b/lib/html.ml
@@ -191,3 +191,8 @@ let html_of_table ?(headings=false) t =
   <:xml<<table>$opt:hd$ $list:tl$</table>&>>
 
 let nil : t = []
+
+let concat els =
+  List.concat els
+
+let append (_to : t) (el : t) = _to @ el

--- a/lib/html.ml
+++ b/lib/html.ml
@@ -196,3 +196,19 @@ let concat els =
   List.concat els
 
 let append (_to : t) (el : t) = _to @ el
+
+module Create = struct
+  type t = element list
+
+  let ul ls =
+    let els =
+      List.map (fun el -> <:html< <li>$el$</li> >>) ls
+      |> concat
+    in <:html< <ul>$els$</ul> >>
+
+  let ol ls =
+    let els =
+      List.map (fun el -> <:html< <li>$el$</li> >>) ls
+      |> concat
+    in <:html< <ol>$els$</ol> >>
+end

--- a/lib/html.ml
+++ b/lib/html.ml
@@ -16,10 +16,13 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
+let (|>) x f = f x
+let (@@) f x = f x
+
 type element = ('a Xml.frag as 'a) Xml.frag
 type t = Xml.t
 
-type tree = [ `Data of string | `El of Xmlm.tag * 'a list ] as 'a
+type tree = [ `Data of string | `El of Xmlm.tag * 'a list | `Css of Css.t ] as 'a
 
 let void_elements = [
   "img";
@@ -211,4 +214,7 @@ module Create = struct
       List.map (fun el -> <:html< <li>$el$</li> >>) ls
       |> concat
     in <:html< <ol>$els$</ol> >>
+
+  let stylesheet css =
+    <:html< <style type="text/css">$css:css$</style> >>
 end

--- a/lib/html.mli
+++ b/lib/html.mli
@@ -114,3 +114,10 @@ type table = t array array
 val html_of_table : ?headings:bool -> table -> t
 
 val nil : t
+
+(** [concat els] combines all the members of [els] into a single [html.t]
+ * @param els a list of the elements to combine *)
+val concat : t list -> t
+
+(** [append par ch] appends ch to par *)
+val append : t -> t -> t

--- a/lib/html.mli
+++ b/lib/html.mli
@@ -121,3 +121,11 @@ val concat : t list -> t
 
 (** [append par ch] appends ch to par *)
 val append : t -> t -> t
+
+module Create : sig
+  type t = element list
+
+  val ul : t list -> t
+
+  val ol : t list -> t
+end

--- a/lib/html.mli
+++ b/lib/html.mli
@@ -115,17 +115,24 @@ val html_of_table : ?headings:bool -> table -> t
 
 val nil : t
 
+val concat : t list -> t
 (** [concat els] combines all the members of [els] into a single [html.t]
  * @param els a list of the elements to combine *)
-val concat : t list -> t
 
-(** [append par ch] appends ch to par *)
 val append : t -> t -> t
+(** [append par ch] appends ch to par *)
 
 module Create : sig
   type t = element list
 
   val ul : t list -> t
+  (** [ul ls] converts an OCaml list of HTML elements to a valid HTML unordered
+   *  list *)
 
   val ol : t list -> t
+  (** [ul ls] converts an OCaml list of HTML elements to a valid HTML ordered
+   *  list *)
+
+  val stylesheet : Css.t -> t
+  (** [stylesheet style] converts a COW CSS type to a valid HTML stylesheet *)
 end

--- a/syntax/xml/quotation.ml
+++ b/syntax/xml/quotation.ml
@@ -50,6 +50,7 @@ object
           | "uri"   -> <:expr< [`Data (Uri.to_string $e$)] >>
           | "alist" -> <:expr< List.map (fun (k,v) -> (("",k),v)) $e$ >>
           | "list"  -> <:expr< List.concat $e$ >>
+          | "css"   -> <:expr< [`Data (Css.to_string $e$)] >>
           | "attrs" ->
 
             <:expr<


### PR DESCRIPTION
I added optional arguments to a few functions in the CSS library, documenting them appropriately. They all use optional arguments, so it shouldn't break any existing code. I also added a new gradient generator, which supports both linear and radial gradients.