### PR TITLE
Fix int32 conversion to float in JSON syntax

### DIFF
--- a/syntax/json/extension.ml
+++ b/syntax/json/extension.ml
@@ -85,7 +85,7 @@ module Json_of = struct
         <:expr< `Float (float_of_int $id$) >>
 
       | Int (Some i) when i <= 32 ->
-        <:expr< `Float (float_of_int $id$) >>
+        <:expr< `Float (Int32.to_float $id$) >>
 
       | Int (Some i) when i <= 64 ->
         <:expr< `Float (Int64.to_float $id$) >>


### PR DESCRIPTION
Currently, the following message appears when using "with json" with
types having int32s:

"Error: This expression has type int32 but an expression was expected of
type int"