### PR TITLE
Change order of arguments for List.map function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Use `$type:expr$` to evaluate `expr` and insert it into a quotation:
   and klass = "items" in
   <:html<
     <ul class=$str:klass$>
-      $list:List.map item ["foo";"bar"]$
+      $list:List.map ["foo";"bar"] item$
     </ul>
   >>
   |> Xml.to_string


### PR DESCRIPTION
Type of List.map is: 'a list -> f:('a -> 'b) -> 'b list.