### PR TITLE
Add ~licls/~dtcls/~ddcls to Html.ul/ol/dl

### DIFF
--- a/lib/html.ml
+++ b/lib/html.ml
@@ -94,6 +94,12 @@ let concat = list
 let li ?cls ?id ?attrs x =
   tag ?cls ?id ?attrs "li" x
 
+let dt ?cls ?id ?attrs x =
+  tag ?cls ?id ?attrs "dt" x
+
+let dd ?cls ?id ?attrs x =
+  tag ?cls ?id ?attrs "dd" x
+
 let ul ?(add_li=true) ?cls ?id ?attrs ls =
   let ls = if add_li then List.map (fun x -> li x) ls else ls in
   tag ?cls ?id ?attrs "ul" (list ls)
@@ -101,6 +107,12 @@ let ul ?(add_li=true) ?cls ?id ?attrs ls =
 let ol ?(add_li=false) ?cls ?id ?attrs ls =
   let ls = if add_li then List.map (fun x -> li x) ls else ls in
   tag ?cls ?id ?attrs "ol" (list ls)
+
+let dl ?(add_dtdd=true) ?cls ?id ?attrs lss =
+  let lss = if add_dtdd
+            then List.map (fun (t, d) -> list [dt t; dd d]) lss
+            else List.map (fun (t, d) -> list [t; d]) lss in
+  tag ?cls ?id ?attrs "dl" (list lss)
 
 let h1 = tag "h1"
 let h2 = tag "h2"

--- a/lib/html.ml
+++ b/lib/html.ml
@@ -100,17 +100,18 @@ let dt ?cls ?id ?attrs x =
 let dd ?cls ?id ?attrs x =
   tag ?cls ?id ?attrs "dd" x
 
-let ul ?(add_li=true) ?cls ?id ?attrs ls =
-  let ls = if add_li then List.map (fun x -> li x) ls else ls in
+let ul ?(add_li=true) ?cls ?id ?attrs ?licls ls =
+  let ls = if add_li then List.map (fun x -> li ?cls:licls x) ls else ls in
   tag ?cls ?id ?attrs "ul" (list ls)
 
-let ol ?(add_li=false) ?cls ?id ?attrs ls =
-  let ls = if add_li then List.map (fun x -> li x) ls else ls in
+let ol ?(add_li=false) ?cls ?id ?attrs ?licls ls =
+  let ls = if add_li then List.map (fun x -> li ?cls:licls x) ls else ls in
   tag ?cls ?id ?attrs "ol" (list ls)
 
-let dl ?(add_dtdd=true) ?cls ?id ?attrs lss =
+let dl ?(add_dtdd=true) ?cls ?id ?attrs ?dtcls ?ddcls lss =
   let lss = if add_dtdd
-            then List.map (fun (t, d) -> list [dt t; dd d]) lss
+            then List.map
+                   (fun (t, d) -> list [dt ?cls:dtcls t; dd ?cls:ddcls d]) lss
             else List.map (fun (t, d) -> list [t; d]) lss in
   tag ?cls ?id ?attrs "dl" (list lss)
 

--- a/lib/html.mli
+++ b/lib/html.mli
@@ -249,12 +249,18 @@ val h6: node
 val small: node
 
 val li: node
+val dt: node
+val dd: node
 
 val ul: ?add_li:bool ->
   ?cls:string -> ?id:string -> ?attrs:(string * string) list -> t list -> t
 
 val ol: ?add_li:bool ->
   ?cls:string -> ?id:string -> ?attrs:(string * string) list -> t list -> t
+
+val dl: ?add_dtdd:bool ->
+  ?cls:string -> ?id:string -> ?attrs:(string * string) list ->
+  (t * t) list -> t
 
 val tag: string -> node
 

--- a/lib/html.mli
+++ b/lib/html.mli
@@ -253,14 +253,16 @@ val dt: node
 val dd: node
 
 val ul: ?add_li:bool ->
-  ?cls:string -> ?id:string -> ?attrs:(string * string) list -> t list -> t
+  ?cls:string -> ?id:string -> ?attrs:(string * string) list ->
+  ?licls:string -> t list -> t
 
 val ol: ?add_li:bool ->
-  ?cls:string -> ?id:string -> ?attrs:(string * string) list -> t list -> t
+  ?cls:string -> ?id:string -> ?attrs:(string * string) list ->
+  ?licls:string -> t list -> t
 
 val dl: ?add_dtdd:bool ->
   ?cls:string -> ?id:string -> ?attrs:(string * string) list ->
-  (t * t) list -> t
+  ?dtcls:string -> ?ddcls:string -> (t * t) list -> t
 
 val tag: string -> node
 


### PR DESCRIPTION
Setting classes of child elements in lists is sometimes useful. For example, the bootstrap 4 navbar:
```
<ul class="nav navbar-nav">
  <li class="nav-item">
    <a class="nav-link" href="#">Home</a>
  </li>
  ...
</ul>
```
See: http://v4-alpha.getbootstrap.com/components/navbar/#supported-content