### PR TITLE
atom feed is a <feed xmlns=../Atom>, not a <tag xmlns=..Atom> (broken…

### DIFF
--- a/src/cow_atom.ml
+++ b/src/cow_atom.ml
@@ -154,7 +154,7 @@ let xml_of_feed ? self f =
     | None   -> Cow_xml.empty
     | Some s -> Cow_xml.tag "link" ~attrs:["rel","self"; "href",s] Cow_xml.empty
   in
-  Cow_xml.(tag "tag" ~attrs:["xmlns","http://www.w3.org/2005/Atom"] (
+  Cow_xml.(tag "feed" ~attrs:["xmlns","http://www.w3.org/2005/Atom"] (
       self
       ++ xml_of_meta f.feed
       ++ list (List.map xml_of_contributor (contributors f.entries))


### PR DESCRIPTION
… since b431d28a3063207bb88f91c7c5456ccecd8b3970)

https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fmirage.io%2Fupdates%2Fatom.xml isn't happy now, neither is https://ocaml.org/community/planet/ (on the right side, `MirageOS` is crossed out with the mouseover "Neither an Atom nor a RSS2 feed".  The root cause is that `<tag xmlns=.../Atom>...</tag>` is emitted by cow (used in mirage-www), whereas feeds are expected to `<feed xmlns=.../Atom>..</feed>`.

I did not compile mirage-www with this change, but I downloaded the mirage feed and manually edited `<tag .. </tag>` to `<feed .. </feed>`, and the validator.w3.org is happy with the feed :)

//cc @samoht @avsm this would be lovely to get merged soon and a have a fresh release drafted to unbreak the mirage feed