### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/cow.opam
+++ b/cow.opam
@@ -16,7 +16,7 @@ doc: "http://mirage.github.io/ocaml-cow/"
 bug-reports: "https://github.com/mirage/ocaml-cow/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "dune" {build & >= "1.1.0"}
+  "dune" {>= "1.1.0"}
   "uri" {>= "1.3.9"}
   "xmlm" {>= "1.1.1"}
   "omd" {>= "0.8.2"}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.